### PR TITLE
add explicitely model input image size

### DIFF
--- a/supervisely/export_weights/src/sly_export_weights.py
+++ b/supervisely/export_weights/src/sly_export_weights.py
@@ -104,7 +104,7 @@ def export_weights(api: sly.Api, task_id, context, state, app_logger):
     elif hasattr(model, 'img_size'):
         imgsz = model.img_size[0]
     elif cfgs_loaded['img_size']:
-        imgsz = cfgs_loaded['img_size']
+        imgsz = cfgs_loaded['img_size'][0]
     else:
         sly.logger.warning(f"Image size is not found in model checkpoint. Use default: {image_size}")
         imgsz = image_size

--- a/supervisely/serve/src/sly_serve.py
+++ b/supervisely/serve/src/sly_serve.py
@@ -4,6 +4,7 @@ import yaml
 import pathlib
 import sys
 import supervisely_lib as sly
+from pathlib import Path
 
 root_source_path = str(pathlib.Path(sys.argv[0]).parents[3])
 sly.logger.info(f"Root source directory: {root_source_path}")
@@ -180,9 +181,12 @@ def preprocess():
         sly.fs.download(url, local_path, my_app.cache, progress)
     elif modelWeightsOptions == "custom":
         final_weights = custom_weights
+        configs = os.path.join(Path(custom_weights).parents[1], 'opt.yaml')
+        configs_local_path = os.path.join(my_app.data_dir, 'opt.yaml')
         file_info = my_app.public_api.file.get_info_by_path(TEAM_ID, custom_weights)
         progress.set(current=0, total=file_info.sizeb)
         my_app.public_api.file.download(TEAM_ID, custom_weights, local_path, my_app.cache, progress.iters_done_report)
+        my_app.public_api.file.download(TEAM_ID, configs, configs_local_path)
     else:
         raise ValueError("Unknown weights option {!r}".format(modelWeightsOptions))
 

--- a/train.py
+++ b/train.py
@@ -433,6 +433,8 @@ def train(hyp, opt, device, tb_writer=None):
 
             # Save model
             if (not opt.nosave) or (final_epoch and not opt.evolve):  # if save
+                model.img_size = opt.img_size
+                ema.ema.img_size = opt.img_size
                 ckpt = {'epoch': epoch,
                         'best_fitness': best_fitness,
                         'training_results': results_file.read_text(),
@@ -453,7 +455,6 @@ def train(hyp, opt, device, tb_writer=None):
                 del ckpt
 
         # end epoch ----------------------------------------------------------------------------------------------------
-
     if plots and opt.sly and train_batches_uploaded is False:
         train_batches_uploaded = True
         upload_train_data_vis()


### PR DESCRIPTION
- добавлен явно(как параметр сети) размер изображения для подачи на вход сети при сохранении весов.
изменен код корня репозитория Yolo: https://github.com/supervisely-ecosystem/yolov5/blob/eb05f7802fc0a64d695a3319edec2612ef229d78/train.py#L436

- обработаны случаи для serve, export_weights, когда в чекпойнте нет значения размера входного изображения.
serve: https://github.com/supervisely-ecosystem/yolov5/blob/adff38001afceba90b2ebdfbce39dafded26a773/supervisely/serve/src/nn_utils.py#L55

export_weights: https://github.com/supervisely-ecosystem/yolov5/blob/adff38001afceba90b2ebdfbce39dafded26a773/supervisely/export_weights/src/sly_export_weights.py#L106