### PR TITLE
handle exception for case with pretrained weights

### DIFF
--- a/supervisely/serve/src/nn_utils.py
+++ b/supervisely/serve/src/nn_utils.py
@@ -43,16 +43,19 @@ def load_model(weights_path, imgsz=640, device='cpu'):
 
     # Load model
     model = attempt_load(weights_path, map_location=device)  # load FP32 model
-    configs_path = os.path.join(Path(weights_path).parents[0], 'opt.yaml')
 
-    with open(configs_path, 'r') as stream:
-        cfgs_loaded = yaml.safe_load(stream)
+    try:
+        configs_path = os.path.join(Path(weights_path).parents[0], 'opt.yaml')
+        with open(configs_path, 'r') as stream:
+            cfgs_loaded = yaml.safe_load(stream)
+    except:
+        cfgs_loaded = None
 
     if hasattr(model, 'module') and hasattr(model.module, 'img_size'):
         imgsz = model.module.img_size[0]
     elif hasattr(model, 'img_size'):
         imgsz = model.img_size[0]
-    elif cfgs_loaded['img_size']:
+    elif cfgs_loaded is not None and cfgs_loaded['img_size']:
         imgsz = cfgs_loaded['img_size'][0]
     else:
         sly.logger.warning(f"Image size is not found in model checkpoint. Use default: {IMG_SIZE}")


### PR DESCRIPTION
try-except block for opt.yaml file reading: for case of pretrained weights there is no opt.yaml file, only for custom weights